### PR TITLE
Add configuration to ~/.emacs.d/init.el, if it exists.

### DIFF
--- a/bin/el4r-rctool
+++ b/bin/el4r-rctool
@@ -267,13 +267,18 @@ dotemacs_block = <<END_OF_BLOCK
 (el4r-boot)
 END_OF_BLOCK
 
-rc.define_patch(".emacs", dotemacs_block, ";;", "%s", :append)
+emacs_init  = ".emacs.d/init.el"
 xemacs_init = ".xemacs/init.el"
-if File.exist?(File.expand_path(xemacs_init, ENV['HOME']))
+dot_emacs   = ".emacs"
+
+if File.exist?(File.expand_path(emacs_init, ENV['HOME']))
+  rc.define_patch(emacs_init, dotemacs_block, ";;", "%s", :append)
+elsif File.exist?(File.expand_path(xemacs_init, ENV['HOME']))
   rc.define_patch(xemacs_init, dotemacs_block, ";;", "%s", :append)
+else
+  rc.define_patch(dot_emacs, dotemacs_block, ";;", "%s", :append)
 end
 
 rc.define_patch("#{home_dir}/init.rb", <<END_OF_BLOCK, "#", "%s", :prepend)
 # This is the el4r initialization file.
 END_OF_BLOCK
-


### PR DESCRIPTION
This patch modifies the el4r-rctool. The original version will check for the existence of ~/.xemacs/init.el, and if it is not present fall back to ~/.emacs.

However, GNU emacs allows the use of ~/.emacs.d/init.el. In this case the rctool would still create .emacs rather than adding the configuration to ~/.emacs.d/init.el, causing the configuration in ~/.emacs.d/init.el to be no longer loaded.
